### PR TITLE
fix(edge): updates incorrect Safari check (#94)

### DIFF
--- a/src/utils/__tests__/ics.spec.js
+++ b/src/utils/__tests__/ics.spec.js
@@ -165,43 +165,35 @@ describe('IcsUtil', () => {
       FileSaver.saveAs.mockClear()
     })
 
-    describe('on Safari', () => {
-      beforeEach(() => {
-        Object.defineProperty(global.navigator, 'userAgent', {
-          value: 'safari',
-          writable: true,
-        })
-      })
-
-      it('should invoke safariFileSave', () => {
-        const data = 'foobar'
-        const title = 'july 4<>'
-        const filename = 'july 4.ics'
-        download(title, data)
-        expect(FileSaver.saveAs).not.toHaveBeenCalled()
-        expect(safariFileSave).toHaveBeenCalledTimes(1)
-        expect(safariFileSave).toHaveBeenCalledWith(data, filename)
-      })
-    })
-
-    describe('on any other browser', () => {
-      beforeEach(() => {
-        Object.defineProperty(global.navigator, 'userAgent', {
-          value: 'chrome',
-          writable: true,
-        })
-      })
-
+    describe('on non-Safari browsers', () => {
       it('should save the data as a file', () => {
         const data = 'foobar'
         const blob = getBlob(data)
         const title = 'july 4<>'
         const filename = 'july 4.ics'
+
         download(title, data)
 
         expect(safariFileSave).not.toHaveBeenCalled()
         expect(FileSaver.saveAs).toHaveBeenCalledTimes(1)
         expect(FileSaver.saveAs).toHaveBeenCalledWith(blob, filename)
+      })
+    })
+
+    describe('on Safari', () => {
+      it('should invoke safariFileSave', () => {
+        const data = 'foobar'
+        const title = 'july 4<>'
+        const filename = 'july 4.ics'
+
+        global.window = Object.create(window)
+        global.window.safari = true
+
+        download(title, data)
+        
+        expect(FileSaver.saveAs).not.toHaveBeenCalled()
+        expect(safariFileSave).toHaveBeenCalledTimes(1)
+        expect(safariFileSave).toHaveBeenCalledWith(data, filename)
       })
     })
   })

--- a/src/utils/ics.js
+++ b/src/utils/ics.js
@@ -102,14 +102,11 @@ export const getRrule = (recurrence) => {
  */
 export const download = (title, data) => {
   const fileName = getFileName(title)
-  const isSafari = ~navigator
-    .userAgent
-    .toLowerCase()
-    .indexOf('safari')
+  const blob = getBlob(data)
 
-  if (isSafari) {
+  if (window.hasOwnProperty('safari')) {
     safariFileSave(data, fileName)
   } else {
-    FileSaver.saveAs(getBlob(data), fileName)
+    FileSaver.saveAs(blob, fileName)
   }
 }


### PR DESCRIPTION
Updates Safari sniffer to check `window.safari` instead of userAgent string. Checking `navigator.userAgent` is unreliable, as Edge contains the word "Safari" in its userAgent string.