### PR TITLE
fix: reduces bundle size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,5 @@ module.exports = {
     ]
   },
   plugins,
-  mode: 'development',
-  devtool: 'eval-source-map'
+  mode: 'production'
 }


### PR DESCRIPTION
Sets Webpack mode to 'production'. This prevents the sourcemap from being bundled with the dist.