### PR TITLE
fix: changes date params to use JS Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@
   /></a> <a href="https://travis-ci.org/jshor/datebook"><img
     src="https://img.shields.io/travis/jshor/datebook.svg?style=for-the-badge"
     alt="Build status"
-  /></a> <a href="https://david-dm.org/jshor/datebook#info=dependencies"><img
-    src="https://img.shields.io/david/jshor/datebook.svg?style=for-the-badge"
-    alt="Dependency Status"
   /></a> <a href="https://npmjs.com/package/datebook"><img
     src="http://img.shields.io/npm/v/datebook.svg?style=for-the-badge"
     alt="npm version"
@@ -57,9 +54,9 @@ import { ICalendar } from 'datebook'
 const icalendar = new ICalendar({
   title: 'Happy Hour',
   location: 'The Bar, New York, NY',
-  description: 'Let\'s blow off some steam from our weekly deployments to enjoy a tall cold one!',
-  start: '2020-07-04T19:00:00',
-  end: '2020-07-04T23:30:00',
+  description: 'Let\'s blow off some steam with a tall cold one!',
+  start: new Date('2022-07-08T19:00:00'),
+  end: new Date('2022-07-08T23:30:00'),
   recurrence: {
     frequency: 'WEEKLY',
     interval: 2

--- a/docs/.vuepress/components/generators/Calendars.vue
+++ b/docs/.vuepress/components/generators/Calendars.vue
@@ -113,6 +113,12 @@ export default {
         recurrence: getFilteredRecurrence(this.config.recurrence)
       }
 
+      config.start = new Date(config.start)
+
+      if (config.end) {
+        config.end = new Date(config.end)
+      }
+
       if (this.allday) {
         delete config.end
       }

--- a/docs/.vuepress/utils/getFilteredRecurrence.js
+++ b/docs/.vuepress/utils/getFilteredRecurrence.js
@@ -7,6 +7,10 @@
 export default function getFilteredRecurrence (value) {
   const recurrence = {...value}
 
+  if (recurrence.end) {
+    recurrence.end = new Date(recurrence.end)
+  }
+
   if (recurrence.frequency === 'DAILY') {
     // these fields are invalid for daily recurrences
     delete recurrence.weekdays

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -24,9 +24,9 @@ import { ICalendar } from 'datebook'
 const calendar = new ICalendar({
   title: 'Happy Hour',
   location: 'The Bar, New York, NY',
-  description: 'Let\'s blow off some steam from our weekly deployments to enjoy a tall cold one!',
-  start: '2020-07-04T19:00:00',
-  end: '2020-07-04T23:30:00',
+  description: 'Let\'s blow off some steam with a tall cold one!',
+  start: new Date('2022-07-08T19:00:00'),
+  end: new Date('2022-07-08T23:30:00'),
   recurrence: {
     frequency: 'WEEKLY',
     interval: 2
@@ -43,18 +43,18 @@ BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
 CLASS:PUBLIC
-DESCRIPTION:Let's blow off some steam from our weekly deployments to enjoy a tall cold one!
-DTSTART:20190704T190000
-DTEND:20190704T230000
+DESCRIPTION:Let's blow off some steam with a tall cold one!
+DTSTART:20220708T190000
+DTEND:20220708T230000
 LOCATION:The Bar, New York, NY
 SUMMARY:Happy Hour
 TRANSP:TRANSPARENT
-RRULE:FREQ=WEEKLY;INTERVAL=2
+RRULE:FREQ=DAILY;INTERVAL=1
 END:VEVENT
 END:VCALENDAR
-UID:nmikriwwll
-DTSTAMP:20200602
-PRODID:localhost:8080
+UID:19hq3v1lm15
+DTSTAMP:20200916
+PRODID:datebook.dev
 ```
 
 ## `YahooCalendar(options)`
@@ -73,9 +73,9 @@ import { YahooCalendar } from 'datebook'
 const yahooCalendar = new YahooCalendar({
   title: 'Happy Hour',
   location: 'The Bar, New York, NY',
-  description: 'Let\'s blow off some steam from our weekly deployments to enjoy a tall cold one!',
-  start: '2020-07-04T19:00:00',
-  end: '2020-07-04T23:30:00',
+  description: 'Let\'s blow off some steam with a tall cold one!',
+  start: new Date('2022-07-08T19:00:00'),
+  end: new Date('2022-07-08T23:30:00'),
   recurrence: {
     frequency: 'WEEKLY',
     interval: 2
@@ -88,7 +88,7 @@ yahooCalendar.render()
 ##### Result:
 
 ```
-https://calendar.yahoo.com/?v=60&title=Happy%20Hour&st=20190704T190000&desc=Let%27s%20blow%20off%20some%20steam%20from%20our%20weekly%20deployments%20to%20enjoy%20a%20tall%20cold%20one!&in_loc=The%20Bar%2C%20New%20York%2C%20NY&RPAT=02Wk&REND=20190610T123112&dur=0200
+https://calendar.yahoo.com/?v=60&title=Happy%20Hour&desc=Let's%20blow%20off%20some%20steam%20with%20a%20tall%20cold%20one!&in_loc=The%20Bar%2C%20New%20York%2C%20NY&st=20220708T190000&dur=0400&RPAT=01Wk&REND=20220708
 ```
 
 This will open a modal in Yahoo! Calendar similar to the following:
@@ -111,9 +111,9 @@ import { GoogleCalendar } from 'datebook'
 const googleCalendar = new GoogleCalendar({
   title: 'Happy Hour',
   location: 'The Bar, New York, NY',
-  description: 'Let\'s blow off some steam from our weekly deployments to enjoy a tall cold one!',
-  start: '2020-07-04T19:00:00',
-  end: '2020-07-04T23:30:00',
+  description: 'Let\'s blow off some steam with a tall cold one!',
+  start: new Date('2022-07-08T19:00:00'),
+  end: new Date('2022-07-08T23:30:00'),
   recurrence: {
     frequency: 'WEEKLY',
     interval: 2
@@ -126,7 +126,7 @@ googleCalendar.render()
 ##### Result:
 
 ```
-https://calendar.google.com/calendar/render?action=TEMPLATE&text=Happy%20Hour&details=Let%27s%20blow%20off%20some%20steam%20from%20our%20weekly%20deployments%20to%20enjoy%20a%20tall%20cold%20one!&location=The%20Bar%2C%20New%20York%2C%20NY&dates=20190704T190000%2F20190704T210000&recur=RRULE%3AFREQ%3DWEEKLY%3BINTERVAL%3D2%3BUNTIL%3D20190610T123926
+https://calendar.google.com/calendar/render?action=TEMPLATE&text=Happy%20Hour&details=Let's%20blow%20off%20some%20steam%20with%20a%20tall%20cold%20one!&location=The%20Bar%2C%20New%20York%2C%20NY&dates=20220708T190000%2F20220708T230000&recur=RRULE%3AFREQ%3DWEEKLY%3BINTERVAL%3D1
 ```
 
 This will open a form in Gmail similar to the following:
@@ -149,9 +149,9 @@ import { OutlookCalendar } from 'datebook'
 const outlookCalendar = new OutlookCalendar({
   title: 'Happy Hour',
   location: 'The Bar, New York, NY',
-  description: 'Let\'s blow off some steam from our weekly deployments to enjoy a tall cold one!',
-  start: '2020-07-04T19:00:00',
-  end: '2020-07-04T23:30:00',
+  description: 'Let\'s blow off some steam with a tall cold one!',
+  start: new Date('2022-07-08T19:00:00'),
+  end: new Date('2022-07-08T23:30:00'),
   recurrence: {
     frequency: 'WEEKLY',
     interval: 2
@@ -164,7 +164,7 @@ outlookCalendar.render()
 ##### Result:
 
 ```
-https://outlook.live.com/calendar/0/deeplink/compose?path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2019-07-04T19%3A00%3A00&enddt=2019-07-04T23%3A00%3A00&subject=Happy%20Hour&body=Let's%20blow%20off%20some%20steam%20from%20our%20weekly%20deployments%20to%20enjoy%20a%20tall%20cold%20one!&location=The%20Bar%2C%20New%20York%2C%20NY&allday=false
+https://outlook.live.com/calendar/0/deeplink/compose?path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2022-07-08T19%3A00%3A00&enddt=2022-07-08T23%3A00%3A00&subject=Happy%20Hour&body=Let's%20blow%20off%20some%20steam%20with%20a%20tall%20cold%20one!&location=The%20Bar%2C%20New%20York%2C%20NY&allday=false
 ```
 
 This will open a modal in Outlook Online calendar similar to the following:

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -30,19 +30,27 @@ A summary description of the event location. Line breaks are automatically strip
 
 ### start
 
-* Type: `string`
+* Type: [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), or `string` (deprecated)
 * Required: **yes**
-* Valid value: any [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) value.
+* Valid value: a valid `Date` reference, or any [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) value (deprecated).
 
 The event start timestamp. See [date formats](date.md) for more information.
 
+:::warning Note
+Specifying dates as strings is deprecated and will be removed in version **5.0.0**.
+:::
+
 ### end
 
-* Type: `string`
+* Type: [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), or `string` (deprecated)
 * Required: **yes**, if not an all-day event
-* Valid value: any [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) value.
+* Valid value: a valid `Date` reference, or any [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) value (deprecated).
 
 The event end timestamp. For all-day events, this field should be omitted. See [date formats](date.md) for more information.
+
+:::warning Deprecation Notice
+Specifying dates as strings is deprecated and will be removed in version **5.0.0**.
+:::
 
 ## Recurrence
 
@@ -54,7 +62,7 @@ The recurrence of an event is how often the event is supposed to occur. Some exa
 
 Recurrence is **optional**.
 
-:::warning Note
+:::warning Deprecation Notice
 This feature is not supported in Outlook online calendars.
 :::
 
@@ -94,14 +102,15 @@ If this parameter is specified in conjunction with [`end`](#recurrence-end), the
 
 ### recurrence.end
 
-* Type: `string`
+* Type: [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), or `string` (deprecated)
 * Required: no
-* Valid value: any [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) value.
+* Valid value: a valid `Date` reference, or any [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) value (deprecated).
 
 The latest date that this event may occur on. See [time formats](date.md) for more information.
 
 :::warning Important
-If this parameter is specified in conjunction with [`end`](#recurrence-end), the recurrence will end either when `count` is completed, or when `end` occurs, whichever happens first.
+* Specifying dates as strings is deprecated and will be removed in version **5.0.0**.
+* If this parameter is specified in conjunction with [`end`](#recurrence-end), the recurrence will end either when `count` is completed, or when `end` occurs, whichever happens first.
 :::
 
 ### recurrence.weekdays

--- a/docs/docs/date.md
+++ b/docs/docs/date.md
@@ -1,10 +1,18 @@
 # Date formats
 
-Dates must be formatted as [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString). Dates not formatted this way will result in `NaN` returned as start and/or end times.
+Dates, including `options.start`, `options.end`, and `recurrence.end`, should be passed in as JavaScript [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects. This provides full control over the date, including the specification of timezones.
+
+## Legacy date support (deprecated)
+
+For backwards compatibility, you may still provide the date as a `string` formatted as [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString). Dates not formatted this way will result in `NaN` returned as start and/or end times.
 
 From the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString):
 
 > [The] simplified extended ISO format (ISO 8601), is always 24 or 27 characters long (`YYYY-MM-DDTHH:mm:ss.sssZ` or `±YYYYYY-MM-DDTHH:mm:ss.sssZ`, respectively). The timezone is always zero UTC offset, as denoted by the suffix "Z."
+
+:::warning Deprecation Notice
+Specifying dates as strings is deprecated and will be removed in version **5.0.0**.
+:::
 
 ## Valid date examples
 

--- a/src/CalendarBase.js
+++ b/src/CalendarBase.js
@@ -1,5 +1,4 @@
-import { FORMAT } from './constants'
-import { parseDate } from './utils/time'
+import { incrementDate, parseDate } from './utils/time'
 
 /**
  * Base calendar class. This class can be extended to add new calendar services.
@@ -12,13 +11,13 @@ class CalendarBase {
    * @param {String} options.description - event description
    * @param {String} options.title - event title
    * @param {String} options.location - event location 
-   * @param {String} options.start - event start time, in [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) format
-   * @param {String} [options.end] - event end time, in [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) format
+   * @param {Date | String} options.start - event start time, in [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) format
+   * @param {Date | String} [options.end] - event end time, in [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) format
    * @param {Object} [options.recurrence]
    * @param {String} [options.recurrence.frequency] - recurrence frequency (`DAILY`, `WEEKLY`, `MONTHLY`, `YEARLY`)
    * @param {Number} [options.recurrence.interval] - time between recurrences
    * @param {Number} [options.recurrence.count] - number of times event should repeat
-   * @param {String} [options.recurrence.end] - date when the last recurrence should occur
+   * @param {Date | String} [options.recurrence.end] - date when the last recurrence should occur
    * @param {String} [options.recurrence.weekstart = 'SU'] - uppercase, first two letters of the day that the week starts on
    * @param {String} [options.recurrence.weekdays] - comma-separated list of uppercase, first two letters of the days the event occurs on
    * @param {String} [options.recurrence.monthdays] - comma-separated list of monthdays	String of numbers
@@ -48,24 +47,27 @@ class CalendarBase {
    * 
    * @private
    * @param {Object} options
-   * @param {String} options.start - event start time
-   * @param {String} [options.end] - event end time
+   * @param {Date | String} options.start - event start time
+   * @param {Date | String} [options.end] - event end time
    * @param {Boolean} [options.allday = false] - whether this is an all-day event
    * @param {Recurrence} [options.recurrence] - event recurrence
    */
   setTimestamps (options) {
     this.allday = !options.end
+    this.start = parseDate(options.start)
     
     if (this.allday) {
       // if allday is specified, make the end date exactly 1 day from the start date
-      this.end = parseDate(options.start)
-      this.end.setDate(this.end.getDate() + 1)
+      this.end = incrementDate(this.start, 1)
     } else {
       this.end = parseDate(options.end)
     }
     
-    this.start = parseDate(options.start)
     this.recurrence = options.recurrence
+
+    if (this.recurrence && this.recurrence.end) {
+      this.recurrence.end = parseDate(this.recurrence.end)
+    }
   }
 }
 

--- a/src/__tests__/CalendarBase.spec.js
+++ b/src/__tests__/CalendarBase.spec.js
@@ -1,5 +1,5 @@
-import moment from 'moment'
 import CalendarBase from '../CalendarBase'
+import { incrementDate } from '../utils/time'
 
 describe('Calendar Base', () => {
   let baseOpts
@@ -7,8 +7,8 @@ describe('Calendar Base', () => {
   beforeEach(() => {
     baseOpts = {
       title: 'Test Event',
-      start: '2019-03-23T17:00:00.000',
-      end: '2019-03-23T21:00:00.000'
+      start: new Date('2019-03-23T17:00:00.000'),
+      end: new Date('2019-03-23T21:00:00.000')
     }
   })
 
@@ -30,8 +30,6 @@ describe('Calendar Base', () => {
 
       expect(testObj.setText).toHaveBeenCalledTimes(1)
       expect(testObj.setTimestamps).toHaveBeenCalledTimes(1)
-      // expect(testObj.setText).toHaveBeenCalledWith(baseOpts)
-      // expect(testObj.setTimestamps).toHaveBeenCalledWith(testOpts)
     })
   })
 
@@ -92,6 +90,7 @@ describe('Calendar Base', () => {
   })
 
   describe('setTimestamps()', () => {
+    const oneDay = 24 * 360 * 1000 // one day in UNIX time
     let calendarObj
 
     beforeEach(() => {
@@ -112,70 +111,65 @@ describe('Calendar Base', () => {
     })
 
     describe('when options has no end', () => {
+
       it('should set allday to true', () => {
         calendarObj.setTimestamps({
-          start: '2019-03-23T17:00:00.000',
+          start: new Date('2019-03-23T17:00:00.000'),
           end: ''
-        });
+        })
 
         expect(calendarObj.allday).toBe(true)
       })
 
       it('should set the end using the start + 1 day', () => {
         const testOpts = {
-          start: '2019-03-23T17:00:00.000',
+          start: new Date('2019-03-23T17:00:00.000'),
           end: ''
         }
 
-        const expectedEnd = moment(testOpts.start)
-          .add(1, 'days')
-          .unix() * 1000
-
         calendarObj.setTimestamps(testOpts)
-        expect(calendarObj.end.getTime()).toBe(expectedEnd)
+
+        expect(calendarObj.start.toString())
+          .toEqual(testOpts.start.toString())
+        expect(calendarObj.end.toString())
+          .toEqual(incrementDate(testOpts.start, 1).toString())
       })
 
       it('should set the start and end without the time of day', () => {
         const testOpts = {
-          start: '2019-03-23T17:00:00.000',
+          start: new Date('2019-03-23T17:00:00.000'),
           end: ''
         }
 
-        const expectedStart = moment(testOpts.start).unix() * 1000
-        const expectedEnd = moment(testOpts.start)
-          .add(1, 'days')
-          .unix() * 1000
-
         calendarObj.setTimestamps(testOpts)
 
-        expect(calendarObj.start.getTime()).toBe(expectedStart)
-        expect(calendarObj.end.getTime()).toBe(expectedEnd)
+        expect(calendarObj.start.toString())
+          .toEqual(testOpts.start.toString())
+        expect(calendarObj.end.toString())
+          .toEqual(incrementDate(testOpts.start, 1).toString())
       })
     })
 
     describe('when options has an end', () => {
       it('should set allday to false', () => {
         calendarObj.setTimestamps({
-          start: '2019-03-23T17:00:00.000',
-          end: '2019-03-23T21:00:00.000'
-        });
+          start: new Date('2019-03-23T17:00:00.000'),
+          end: new Date('2019-03-23T21:00:00.000')
+        })
 
-        expect(calendarObj.allday).toBe(false);
+        expect(calendarObj.allday).toBe(false)
       })
 
       it('should set the start and end including the time of day', () => {
         const testOpts = {
-          start: '2019-03-23T17:00:00.000',
-          end: '2019-03-23T21:00:00.000'
+          start: new Date('2019-03-23T17:00:00.000'),
+          end: new Date('2019-03-23T21:00:00.000')
         }
-
-        const expectedStart = moment(testOpts.start).unix() * 1000
-        const expectedEnd = moment(testOpts.end).unix() * 1000
 
         calendarObj.setTimestamps(testOpts)
 
-        expect(calendarObj.start.getTime()).toBe(expectedStart)
-        expect(calendarObj.end.getTime()).toBe(expectedEnd)
+        expect(calendarObj.start).toEqual(testOpts.start)
+        expect(calendarObj.end).toEqual(testOpts.end)
       })
     })
   })

--- a/src/__tests__/GoogleCalendar.spec.js
+++ b/src/__tests__/GoogleCalendar.spec.js
@@ -14,7 +14,7 @@ describe('GoogleCalendar', () => {
     title: 'Test Event',
     description: 'Test Description',
     location: 'Rockefeller Center',
-    start: '2019-03-23T17:00:00.000'
+    start: new Date('2019-03-23T17:00:00.000')
   }
   const baseParams = {
     text: 'Test Event',

--- a/src/__tests__/ICalendar.spec.js
+++ b/src/__tests__/ICalendar.spec.js
@@ -14,8 +14,8 @@ describe('ICalendar', () => {
       title: 'Fun Party',
       description: 'BYOB',
       location: 'New York',
-      start: '2019-07-04T19:00:00.000',
-      end: '2019-07-04T21:00:00.000',
+      start: new Date('2019-07-04T19:00:00.000'),
+      end: new Date('2019-07-04T21:00:00.000'),
     }
   })
 

--- a/src/__tests__/OutlookCalendar.spec.js
+++ b/src/__tests__/OutlookCalendar.spec.js
@@ -21,8 +21,8 @@ describe('Outlook Calendar', () => {
       testOpts.title = 'Music Concert'
       testOpts.location = 'New York'
       testOpts.description = 'a description'
-      testOpts.start = '2019-03-23T17:00:00.000'
-      testOpts.end = '2019-03-23T21:00:00.000'
+      testOpts.start = new Date('2019-03-23T17:00:00.000')
+      testOpts.end = new Date('2019-03-23T21:00:00.000')
     })
 
     afterEach(() => {

--- a/src/__tests__/YahooCalendar.spec.js
+++ b/src/__tests__/YahooCalendar.spec.js
@@ -24,7 +24,7 @@ describe('YahooCalendar', () => {
       title: 'Fun Party',
       description: 'BYOB',
       location: 'New York',
-      start: '2019-07-04T19:00:00.000'
+      start: new Date('2019-07-04T19:00:00.000')
     }
   })
 

--- a/src/utils/calendars.js
+++ b/src/utils/calendars.js
@@ -2,21 +2,26 @@ import GoogleCalendar from '../GoogleCalendar'
 import YahooCalendar from '../YahooCalendar'
 import ICalendar from '../ICalendar'
 import OutlookCalendar from '../OutlookCalendar'
+import warn from './warn'
 
 export default class Calendars {
   static getGoogleCalendarUrl (options) {
+    warn('`Calendars.getGoogleCalendarUrl()`')
     return (new GoogleCalendar(options)).render()
   }
   
   static getYahooCalendarUrl (options) {
+    warn('`Calendars.getYahooCalendarUrl()`')
     return (new YahooCalendar(options)).render()
   }
 
   static getMicrosoftCalendarUrl (options) {
+    warn('`Calendars.getMicrosoftCalendarUrl()`')
     return (new OutlookCalendar(options)).render()
   }
   
   static downloadIcs (options) {
+    warn('`Calendars.downloadIcs()`')
     return (new ICalendar(options)).download()
   }
 }

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,4 +1,5 @@
 import { FORMAT } from '../constants'
+import warn from './warn'
 
 /**
  * Adds a leading zero to a single-digit string and returns a two-digit string.
@@ -38,11 +39,16 @@ export const formatTimestampDate = (d, format) => {
 /**
  * Parses the given string as a JS Date() object.
  * 
- * @param {String} str
+ * @param {Date | String} date
  * @returns {Date}
  */
-export const parseDate = (str) => { // TODO: check if `time` is valid date
-  return new Date(str)
+export const parseDate = (date) => {
+  if (typeof date === 'string') {
+    warn('Passing in `date` as a string')
+    return new Date(date)
+  }
+
+  return date
 }
 
 /**
@@ -63,4 +69,21 @@ export const formatTimestampString = (str, format) => {
  */
 export const getTimeCreated = () => {
   return formatTimestampDate(new Date(), FORMAT.DATE)
+}
+
+/**
+ * Increments dates by the given number of days.
+ * This will account for edge cases, such as leap years.
+ * 
+ * @param {Date} dateInput - date to increment
+ * @param {Number} increment - number of days
+ * @returns {Date}
+ */
+export const incrementDate = (dateInput, increment) => {
+  const additionalTime = increment * 86400000
+  const newDate = new Date()
+  
+  newDate.setTime(dateInput.getTime() + additionalTime)
+
+  return newDate
 }

--- a/src/utils/warn.js
+++ b/src/utils/warn.js
@@ -1,0 +1,3 @@
+export default function warn (str) {
+  console.warn(`[datebook.js] ${str} is deprecated and will be removed in v5.0.0.`)
+}


### PR DESCRIPTION
This deprecates the usage of passing in ISO 8601 strings as dates. This change fixes date-conversion and timezone issues #93, #104, and #107 by providing the consumer with full control over the date and having Datebook no longer mutate it.