### PR TITLE
feat(ics): allow providing .ics filename, without relying on title

### DIFF
--- a/docs/docs/icalendar.md
+++ b/docs/docs/icalendar.md
@@ -178,6 +178,8 @@ DTSTAMP:20200916
 PRODID:datebook.dev
 ```
 
-## `download()`
+## `download(fileName?: string)`
+
+* **`fileName: string`** - optional file name
 
 Downloads a `.ics` file on the user's browser for use in local calendars and email clients.

--- a/src/ICalendar.ts
+++ b/src/ICalendar.ts
@@ -130,9 +130,11 @@ export default class ICalendar extends CalendarBase {
    * Downloads the rendered iCalendar.
    *
    * @remark Only works in browsers.
+   *
+   * @param {string} filename optional explicit filename, if not provided then will be constructed from title
    */
-  public download = (): void => {
-    ics.download(this.title, this.render())
+  public download = (filename?: string): void => {
+    ics.download(filename || ics.getFileName(this.title), this.render())
   }
 
   /**

--- a/src/ICalendar.ts
+++ b/src/ICalendar.ts
@@ -131,10 +131,10 @@ export default class ICalendar extends CalendarBase {
    *
    * @remark Only works in browsers.
    *
-   * @param {string} filename optional explicit filename, if not provided then will be constructed from title
+   * @param {string} fileName optional explicit file name, if not provided then will be constructed from title
    */
-  public download = (filename?: string): void => {
-    ics.download(filename || ics.getFileName(this.title), this.render())
+  public download = (fileName?: string): void => {
+    ics.download(fileName || ics.getFileName(this.title), this.render())
   }
 
   /**

--- a/src/__tests__/ICalendar.spec.ts
+++ b/src/__tests__/ICalendar.spec.ts
@@ -156,7 +156,27 @@ describe('ICalendar', () => {
 
       expect(obj.render).toHaveBeenCalledTimes(1)
       expect(ics.download).toHaveBeenCalledTimes(1)
-      expect(ics.download).toHaveBeenCalledWith(baseOpts.title, mockRender)
+      expect(ics.download).toHaveBeenCalledWith(`${baseOpts.title}.ics`, mockRender)
+    })
+  })
+
+  describe('download(filename)', () => {
+    it('should call render and the download util with provided filename', () => {
+      const obj = new ICalendar(baseOpts)
+      const mockRender = 'renderedstring'
+
+      jest
+        .spyOn(ics, 'download')
+        .mockImplementation(jest.fn())
+      jest
+        .spyOn(obj, 'render')
+        .mockReturnValue(mockRender)
+
+      obj.download('test.ics')
+
+      expect(obj.render).toHaveBeenCalledTimes(1)
+      expect(ics.download).toHaveBeenCalledTimes(1)
+      expect(ics.download).toHaveBeenCalledWith('test.ics', mockRender)
     })
   })
 

--- a/src/utils/ics.ts
+++ b/src/utils/ics.ts
@@ -100,11 +100,10 @@ const isSafari = (): boolean => {
 /**
  * Downloads the given ics as an iCalendar file.
  *
- * @param {string} title - title of the event
+ * @param {string} fileName - filename of the event file
  * @param {string} data - ics data
  */
-const download = (title: string, data: string): void => {
-  const fileName = getFileName(title)
+const download = (fileName: string, data: string): void => {
 
   if (isSafari()) {
     safariFileSave(data, fileName)


### PR DESCRIPTION
Background for this PR - if user specifies event title that is not in English (e.g. in Russian) the filename logic will strip all non-English characters, leaving filename as [bunch of spaces].ics