### PR TITLE
feat(outlook): implements setHost

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -55,6 +55,10 @@ module.exports = {
                 path: '/config/basic.md'
               },
               {
+                title: 'Attendees',
+                path: '/config/attendees.md'
+              },
+              {
                 title: 'Recurrences',
                 path: '/config/recurrence.md'
               },

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@ home: true
 heroImage: /assets/logo.svg
 actionText: Read the docs →
 actionLink: /docs/
-footer: © 2020 Datebook.
+footer: © 2021 Datebook.
 ---
 
 <div class="features">

--- a/docs/config/recurrence.md
+++ b/docs/config/recurrence.md
@@ -55,7 +55,7 @@ If this parameter is specified in conjunction with [`end`](#end), the recurrence
 The latest date that this event may occur on.
 
 :::warning Important
-If this parameter is specified in conjunction with [`end`](#end), the recurrence will end either when `count` is completed, or when `end` occurs, whichever happens first.
+If this parameter is specified in conjunction with [`count`](#count), the recurrence will end either when `count` is completed, or when `end` occurs, whichever happens first.
 :::
 
 ## weekdays

--- a/docs/docs/outlook.md
+++ b/docs/docs/outlook.md
@@ -22,6 +22,23 @@ const options: CalendarOptions = {
 const outlookCalendar = new OutlookCalendar(options)
 ```
 
+## `setHost(host: string): OutlookCalendar`
+
+Sets the host service type. The default host for Outlook is **`live`**.
+
+Returns the `OutlookCalendar` instance.
+
+### Valid hosts
+
+* **`live`** - For personal Outlook accounts (default).
+* **`office`** - For Office365 Outlook accounts.
+
+### Example
+
+```ts
+outlookCalendar.setHost('outlook.office.com')
+```
+
 ## `setParam(key: string, value: string): OutlookCalendar`
 
 Sets a parameter on the URL. This may be used to either set additional optional properties, or override existing ones. Pass a value of `null` to remove an existing property.

--- a/src/OutlookCalendar.ts
+++ b/src/OutlookCalendar.ts
@@ -10,9 +10,13 @@ import CalendarOptions from './types/CalendarOptions'
  * @remark Outlook Calendar's query string params do not support recurrence.
  */
 export default class OutlookCalendar extends CalendarBase {
+  /** Base URL for the host service. */
+  private baseUrl: string = URL.OUTLOOK
+
   constructor (opts: CalendarOptions) {
     super(opts)
     this.setInitialParams()
+    this.setHost('live')
   }
 
   /**
@@ -41,14 +45,27 @@ export default class OutlookCalendar extends CalendarBase {
   }
 
   /**
+   * Sets the host service type. The default host for Outlook is **`live`**.
+   *
+   * @param {string} host - `live` (for personal accounts) or `office` (for Office365)
+   * @returns {OutlookCalendar}
+   */
+  public setHost = (host: string) => {
+    if (['live', 'office'].includes(host)) {
+      this.baseUrl = URL.OUTLOOK.replace('{{host}}', host)
+    }
+
+    return this
+  }
+
+  /**
    * Generates the Outlook url.
    *
    * @returns {string}
    */
   public render = (): string => {
-    const baseUrl = URL.OUTLOOK
     const queryString = data.toQueryString(this.params)
 
-    return `${baseUrl}?${queryString}`
+    return `${this.baseUrl}?${queryString}`
   }
 }

--- a/src/__tests__/OutlookCalendar.spec.ts
+++ b/src/__tests__/OutlookCalendar.spec.ts
@@ -16,6 +16,43 @@ describe('Outlook Calendar', () => {
     })).toBeInstanceOf(CalendarBase)
   })
 
+  describe('setHost()', () => {
+    let outlookCalendar: OutlookCalendar
+
+    beforeEach(() => {
+      outlookCalendar = new OutlookCalendar({
+        title: 'Fun Party',
+        description: 'BYOB',
+        location: 'New York',
+        start: new Date('2019-07-04T19:00:00.000')
+      })
+    })
+
+    it('should render the base URL as outlook.office.com if `office` is passed', () => {
+      const url = outlookCalendar
+        .setHost('office')
+        .render()
+
+      expect(url.substring(0, 26)).toEqual('https://outlook.office.com')
+    })
+
+    it('should render the base URL as outlook.live.com if `live` is passed', () => {
+      const url = outlookCalendar
+        .setHost('live')
+        .render()
+
+      expect(url.substring(0, 24)).toEqual('https://outlook.live.com')
+    })
+
+    it('should render the base URL as outlook.live.com if an invalid host is passed', () => {
+      const url = outlookCalendar
+        .setHost('some_invalid_host')
+        .render()
+
+      expect(url.substring(0, 24)).toEqual('https://outlook.live.com')
+    })
+  })
+
   describe('render()', () => {
     const testOpts: CalendarOptions = {
       start: new Date('2019-03-23T17:00:00.000')
@@ -27,14 +64,6 @@ describe('Outlook Calendar', () => {
       testOpts.description = 'a description'
       testOpts.start = new Date('2019-03-23T17:00:00.000')
       testOpts.end = new Date('2019-03-23T21:00:00.000')
-    })
-
-    it('should use the proper base URL', () => {
-      const obj = new OutlookCalendar(testOpts)
-      const result = obj.render()
-      const baseUrl = result.split('?')[0]
-
-      expect(baseUrl).toBe(URL.OUTLOOK)
     })
 
     describe('when the event is not an all-day event', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,5 @@ export const FORMAT = {
 export const URL = {
   YAHOO: 'https://calendar.yahoo.com/',
   GOOGLE: 'https://calendar.google.com/calendar/render',
-  OUTLOOK: 'https://outlook.live.com/calendar/0/deeplink/compose'
+  OUTLOOK: 'https://outlook.{{host}}.com/calendar/0/deeplink/compose'
 }


### PR DESCRIPTION
Implements setHost, which allows the consumer to specify whether they
want Outlook to render a personal calendar URL or an Office365 one. (#149)