### PR TITLE
fix: for yahoo time not in UTC

### DIFF
--- a/src/CalendarBase.ts
+++ b/src/CalendarBase.ts
@@ -66,12 +66,8 @@ abstract class CalendarBase implements ICalendarBase {
     this.isAllDay = !options.end
     this.start = options.start
 
-    if (options.end) {
-      this.end = options.end
-    } else {
-      // if no end date is specified, make the end date exactly 1 day from the start date
-      this.end = time.incrementDate(this.start, 1)
-    }
+    // if no end date is specified, make the end date exactly 1 day from the start date
+    this.end = options.end || time.incrementDate(this.start, 1)
 
     this.recurrence = options.recurrence
   }
@@ -82,11 +78,7 @@ abstract class CalendarBase implements ICalendarBase {
    * @param {CalendarOptions} options
    */
   protected setAttendees (options: CalendarOptions): void {
-    if (Array.isArray(options.attendees)) {
-      this.attendees = options.attendees
-    } else {
-      this.attendees = []
-    }
+    this.attendees = Array.isArray(options.attendees) ? options.attendees : []
   }
 
   /**

--- a/src/YahooCalendar.ts
+++ b/src/YahooCalendar.ts
@@ -41,13 +41,13 @@ export default class YahooCalendar extends CalendarBase {
     if (this.isAllDay) {
       this
         .setParam('dur', 'allday')
-        .setParam('st', time.formatDate(this.start, FORMAT.DATE))
+        .setParam('st', time.formatDateNoUtc(this.start, FORMAT.DATE))
     } else {
-      this.setParam('st', time.formatDate(this.start, FORMAT.FULL))
+      this.setParam('st', time.formatDateNoUtc(this.start, FORMAT.FULL))
 
       if (time.getHoursDiff(this.start.getTime(), this.end.getTime()) > 99) {
         // Yahoo only supports up to 99 hours, so we are forced to specify the end time instead of the duration
-        this.setParam('et', time.formatDate(this.end, FORMAT.FULL))
+        this.setParam('et', time.formatDateNoUtc(this.end, FORMAT.FULL))
       } else {
         // we prefer specifying duration in lieu of end time, because apparently Yahoo's end time is buggy w.r.t. timezones
         this.setParam('dur', time.getDuration(this.start.getTime(), this.end.getTime()))
@@ -63,12 +63,12 @@ export default class YahooCalendar extends CalendarBase {
       this.setParam('RPAT', yahooUtils.getRecurrence(this.recurrence))
 
       if (this.recurrence.end) {
-        this.setParam('REND', time.formatDate(this.recurrence.end, FORMAT.DATE))
+        this.setParam('REND', time.formatDateNoUtc(this.recurrence.end, FORMAT.DATE))
       } else {
         const days = time.getRecurrenceLengthDays(this.recurrence)
         const rend = time.incrementDate(this.end, Math.ceil(days))
 
-        this.setParam('REND', time.formatDate(rend, FORMAT.DATE))
+        this.setParam('REND', time.formatDateNoUtc(rend, FORMAT.DATE))
       }
     }
   }

--- a/src/YahooCalendar.ts
+++ b/src/YahooCalendar.ts
@@ -43,11 +43,11 @@ export default class YahooCalendar extends CalendarBase {
         .setParam('dur', 'allday')
         .setParam('st', time.formatDateNoUtc(this.start, FORMAT.DATE))
     } else {
-      this.setParam('st', time.formatDateNoUtc(this.start, FORMAT.FULL))
+      this.setParam('st', time.formatDateNoUtc(this.start, FORMAT.NO_UTC_FULL))
 
       if (time.getHoursDiff(this.start.getTime(), this.end.getTime()) > 99) {
         // Yahoo only supports up to 99 hours, so we are forced to specify the end time instead of the duration
-        this.setParam('et', time.formatDateNoUtc(this.end, FORMAT.FULL))
+        this.setParam('et', time.formatDateNoUtc(this.end, FORMAT.NO_UTC_FULL))
       } else {
         // we prefer specifying duration in lieu of end time, because apparently Yahoo's end time is buggy w.r.t. timezones
         this.setParam('dur', time.getDuration(this.start.getTime(), this.end.getTime()))

--- a/src/__tests__/YahooCalendar.spec.ts
+++ b/src/__tests__/YahooCalendar.spec.ts
@@ -114,7 +114,7 @@ describe('YahooCalendar', () => {
               title: 'Fun Party',
               desc: 'BYOB',
               in_loc: 'New York',
-              st: time.formatDateNoUtc(testOpts.start, FORMAT.FULL),
+              st: time.formatDateNoUtc(testOpts.start, FORMAT.NO_UTC_FULL),
               dur: '0200'
             }
             expect(params).toMatchObject(expectedObj)
@@ -137,8 +137,8 @@ describe('YahooCalendar', () => {
               title: 'Fun Party',
               desc: 'BYOB',
               in_loc: 'New York',
-              st: time.formatDateNoUtc(start, FORMAT.FULL),
-              et: time.formatDateNoUtc(end, FORMAT.FULL)
+              st: time.formatDateNoUtc(start, FORMAT.NO_UTC_FULL),
+              et: time.formatDateNoUtc(end, FORMAT.NO_UTC_FULL)
             }
             expect(params).toMatchObject(expectedObj)
             expect(expectedObj).toMatchObject(params)
@@ -167,7 +167,7 @@ describe('YahooCalendar', () => {
             desc: 'BYOB',
             in_loc: 'New York',
             dur: '0200',
-            st: time.formatDateNoUtc(testOpts.start, FORMAT.FULL),
+            st: time.formatDateNoUtc(testOpts.start, FORMAT.NO_UTC_FULL),
             RPAT: '01Dy',
             REND: time.formatDateNoUtc(recurrenceEnd, FORMAT.DATE)
           }
@@ -203,7 +203,7 @@ describe('YahooCalendar', () => {
           desc: 'BYOB',
           in_loc: 'New York',
           dur: 'allday',
-          st: time.formatDate(testOpts.start, FORMAT.DATE),
+          st: time.formatDateNoUtc(testOpts.start, FORMAT.DATE),
           inv_list: 'John Doe <john@doe.com>,Jane Doe <jane@doe.com>'
         }
 

--- a/src/__tests__/YahooCalendar.spec.ts
+++ b/src/__tests__/YahooCalendar.spec.ts
@@ -114,7 +114,7 @@ describe('YahooCalendar', () => {
               title: 'Fun Party',
               desc: 'BYOB',
               in_loc: 'New York',
-              st: time.formatDate(testOpts.start, FORMAT.FULL),
+              st: time.formatDateNoUtc(testOpts.start, FORMAT.FULL),
               dur: '0200'
             }
             expect(params).toMatchObject(expectedObj)
@@ -137,8 +137,8 @@ describe('YahooCalendar', () => {
               title: 'Fun Party',
               desc: 'BYOB',
               in_loc: 'New York',
-              st: time.formatDate(start, FORMAT.FULL),
-              et: time.formatDate(end, FORMAT.FULL)
+              st: time.formatDateNoUtc(start, FORMAT.FULL),
+              et: time.formatDateNoUtc(end, FORMAT.FULL)
             }
             expect(params).toMatchObject(expectedObj)
             expect(expectedObj).toMatchObject(params)
@@ -167,9 +167,9 @@ describe('YahooCalendar', () => {
             desc: 'BYOB',
             in_loc: 'New York',
             dur: '0200',
-            st: time.formatDate(testOpts.start, FORMAT.FULL),
+            st: time.formatDateNoUtc(testOpts.start, FORMAT.FULL),
             RPAT: '01Dy',
-            REND: time.formatDate(recurrenceEnd, FORMAT.DATE)
+            REND: time.formatDateNoUtc(recurrenceEnd, FORMAT.DATE)
           }
           expect(params).toMatchObject(expectedObj)
         })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const FORMAT = {
   DATE: 'YYYYMMDD',
   TIME: 'ThhmmssZ',
   FULL: 'YYYYMMDDThhmmssZ',
+  NO_UTC_FULL: 'YYYYMMDDThhmmss',
   OUTLOOK_DATE: 'YYYY-MM-DD',
   OUTLOOK_TIME: 'Thh:mm:ssZ',
   OUTLOOK_FULL: 'YYYY-MM-DDThh:mm:ssZ'

--- a/src/utils/__tests__/time.spec.ts
+++ b/src/utils/__tests__/time.spec.ts
@@ -84,6 +84,15 @@ describe('time utils', () => {
     })
   })
 
+  describe('formatDateNoUTC()', () => {
+    it('should format the timestamp with the given formats, without Z at the end', () => {
+      const timestamp = '2019-03-23T17:00:00-03:00'
+      const actualDateOutput = time.formatDateNoUtc(new Date(timestamp), FORMAT.DATE)
+
+      expect(actualDateOutput).toBe('20190323')
+    })
+  })
+
   describe('incrementDate()', () => {
     it('should increment the date by one day', () => {
       const incrementedDate = time.incrementDate(new Date('2020-04-01'), 1)

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -91,6 +91,32 @@ const formatDate = (d: Date = new Date(), format: string): string => {
     }, format)
 }
 
+
+/**
+ * Formats the given JS Date() object to the given format, not using UTC
+ * Format defaults to: YYYYMMDDTHHMMss
+ *
+ * @param {Date} [d = new Date()]
+ * @param {string} format
+ * @returns {string}
+ */
+const formatDateNoUtc = (d: Date = new Date(), format: string): string => {
+  const dateValues: Record<string, string | number> = {
+    YYYY: d.getUTCFullYear(),
+    MM: addLeadingZero(d.getMonth() + 1),
+    DD: addLeadingZero(d.getDate()),
+    hh: addLeadingZero(d.getHours()),
+    mm: addLeadingZero(d.getMinutes()),
+    ss: addLeadingZero(d.getSeconds())
+  }
+
+  return Object
+    .keys(dateValues)
+    .reduce((date: string, key: string): string => {
+      return date.replace(key, dateValues[key].toString())
+    }, format)
+}
+
 /**
  * Returns the current timestamp.
  *
@@ -123,6 +149,7 @@ export default {
   getHoursDiff,
   getRecurrenceLengthDays,
   formatDate,
+  formatDateNoUtc,
   getTimeCreated,
   incrementDate
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -102,7 +102,7 @@ const formatDate = (d: Date = new Date(), format: string): string => {
  */
 const formatDateNoUtc = (d: Date = new Date(), format: string): string => {
   const dateValues: Record<string, string | number> = {
-    YYYY: d.getUTCFullYear(),
+    YYYY: d.getFullYear(),
     MM: addLeadingZero(d.getMonth() + 1),
     DD: addLeadingZero(d.getDate()),
     hh: addLeadingZero(d.getHours()),


### PR DESCRIPTION
I had problems with yahoo calendar links, only in Yahoo the displayed time was not correct in my timezone, whereas on Google it was displayed correctly.
So I have changed the way to formatDate only for Yahoo.
