### PR TITLE
fix(ics): fixes all-day timestamps #157

### DIFF
--- a/src/ICalendar.ts
+++ b/src/ICalendar.ts
@@ -35,15 +35,23 @@ export default class ICalendar extends CalendarBase {
       .setMeta('UID', ics.getUid())
       .setMeta('DTSTAMP', time.getTimeCreated())
       .setMeta('PRODID', ics.getProdId())
-
-    this
       .addProperty('CLASS', 'PUBLIC')
       .addProperty('DESCRIPTION', ics.formatText(this.description))
-      .addProperty('DTSTART', time.formatDate(this.start, FORMAT.FULL))
-      .addProperty('DTEND', time.formatDate(this.end, FORMAT.FULL))
       .addProperty('LOCATION', ics.formatText(this.location))
       .addProperty('SUMMARY', ics.formatText(this.title))
       .addProperty('TRANSP', 'TRANSPARENT')
+
+    if (this.isAllDay) {
+      // for all-day events, omit the time and just place dates
+      this
+        .addProperty('DTSTART;VALUE=DATE', time.formatDateNoUtc(this.start, FORMAT.DATE))
+        .addProperty('DTEND;VALUE=DATE', time.formatDateNoUtc(time.incrementDate(this.start, 1), FORMAT.DATE))
+    } else {
+      // otherwise, set the full start and end dates
+      this
+        .addProperty('DTSTART', time.formatDate(this.start, FORMAT.FULL))
+        .addProperty('DTEND', time.formatDate(this.end, FORMAT.FULL))
+    }
 
     if (this.recurrence) {
       this.addProperty('RRULE', ics.getRrule(this.recurrence))

--- a/src/__tests__/ICalendar.spec.ts
+++ b/src/__tests__/ICalendar.spec.ts
@@ -24,6 +24,20 @@ describe('ICalendar', () => {
     expect(result).toBeInstanceOf(CalendarBase)
   })
 
+  it('should render just the date for an all-day event', () => {
+    const obj = new ICalendar({
+      title: 'Fun Party',
+      description: 'BYOB',
+      location: 'New York',
+      start: new Date('2019-07-04T19:00:00.000')
+    })
+
+    expect(obj.render()).toContain([
+      `DTSTART;VALUE=DATE:${time.formatDateNoUtc(baseOpts.start, FORMAT.DATE)}`,
+      `DTEND;VALUE=DATE:${time.formatDateNoUtc(time.incrementDate(baseOpts.start, 1), FORMAT.DATE)}`
+    ].join('\n'))
+  })
+
   describe('addAlarm()', () => {
     let obj: ICalendar
 
@@ -242,11 +256,11 @@ describe('ICalendar', () => {
         'BEGIN:VEVENT',
         'CLASS:PUBLIC',
         `DESCRIPTION:${baseOpts.description}`,
-        `DTSTART:${time.formatDate(baseOpts.start, FORMAT.FULL)}`,
-        `DTEND:${time.formatDate(baseOpts.end, FORMAT.FULL)}`,
         `LOCATION:${baseOpts.location}`,
         `SUMMARY:${baseOpts.title}`,
         'TRANSP:TRANSPARENT',
+        `DTSTART:${time.formatDate(baseOpts.start, FORMAT.FULL)}`,
+        `DTEND:${time.formatDate(baseOpts.end, FORMAT.FULL)}`,
         'END:VEVENT',
         'END:VCALENDAR',
         `UID:${mockUuid}`,
@@ -281,22 +295,22 @@ describe('ICalendar', () => {
         'BEGIN:VEVENT',
         'CLASS:PUBLIC',
         `DESCRIPTION:${secondEventOpts.description}`,
-        `DTSTART:${time.formatDate(secondEventOpts.start, FORMAT.FULL)}`,
-        `DTEND:${time.formatDate(baseOpts.end, FORMAT.FULL)}`,
         `LOCATION:${secondEventOpts.location}`,
         `SUMMARY:${secondEventOpts.title}`,
         'TRANSP:TRANSPARENT',
+        `DTSTART:${time.formatDate(secondEventOpts.start, FORMAT.FULL)}`,
+        `DTEND:${time.formatDate(baseOpts.end, FORMAT.FULL)}`,
         'END:VEVENT',
 
         // base event
         'BEGIN:VEVENT',
         'CLASS:PUBLIC',
         `DESCRIPTION:${baseOpts.description}`,
-        `DTSTART:${time.formatDate(baseOpts.start, FORMAT.FULL)}`,
-        `DTEND:${time.formatDate(baseOpts.end, FORMAT.FULL)}`,
         `LOCATION:${baseOpts.location}`,
         `SUMMARY:${baseOpts.title}`,
         'TRANSP:TRANSPARENT',
+        `DTSTART:${time.formatDate(baseOpts.start, FORMAT.FULL)}`,
+        `DTEND:${time.formatDate(baseOpts.end, FORMAT.FULL)}`,
         'END:VEVENT',
 
         'END:VCALENDAR',


### PR DESCRIPTION
Updates DTSTART and DTEND params in iCalendar such that the dates are formatted as dates with times omitted for all-day events. This works around the issue of timestamps interpreted differently in some calendar apps.