### PR TITLE
Escapes special characters for text types

### DIFF
--- a/src/utils/__tests__/ics.spec.ts
+++ b/src/utils/__tests__/ics.spec.ts
@@ -14,16 +14,20 @@ describe('IcsUtil', () => {
   afterEach(() => jest.resetAllMocks())
 
   describe('formatText()', () => {
-    const str = 'foo\nbar\n\nbaz'
-
     it('should backslash escape newlines', () => {
-      const formatted = ics.formatText(str)
+      const formatted = ics.formatText('foo\nbar\n\nbaz')
 
       expect(formatted).toBe('foo\\nbar\\n\\nbaz')
     })
 
+    it('should backslash escape special characters', () => {
+      const formatted = ics.formatText('foo, bar, baz; qux\\ quux')
+
+      expect(formatted).toBe('foo\\, bar\\, baz\\; qux\\\\ quux')
+    })
+
     it('should return the full string if maxLength is undefined', () => {
-      const formatted = ics.formatText(str)
+      const formatted = ics.formatText('foo\nbar\n\nbaz')
 
       expect(formatted).toBe('foo\\nbar\\n\\nbaz')
     })

--- a/src/utils/ics.ts
+++ b/src/utils/ics.ts
@@ -12,7 +12,10 @@ import { FORMAT } from '../constants'
  * @returns {string}
  */
 const formatText = (str = ''): string => {
-  return str.replace(/\n/g, '\\n')
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/[,;]/g, '\\$&')
 }
 
 /**


### PR DESCRIPTION
Escapes special characters `,` `;` and `\` for TEXT types.

Fixes #179 

* * *

Sorry, I accidentally reformatted the files in my original PR.