### PR TITLE
Fixing main refer to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/jshor/datebook/issues"
   },
   "homepage": "https://datebook.dev",
-  "main": "dist/datebook.min.mjs",
+  "main": "dist/datebook.min.js",
   "module": "dist/datebook.min.mjs",
   "types": "dist/src/index.d.ts",
   "files": [


### PR DESCRIPTION
If main refers to the modules, it issues some Errors when using require.
The following Error is fixed with the PR:
```sh
node:internal/modules/cjs/loader:1111
    throw new ERR_REQUIRE_ESM(filename, true);
    ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/datebook/dist/datebook.min.mjs not supported.
Instead change the require of /app/node_modules/datebook/dist/datebook.min.mjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/app/calendarGen/calGenerator.js:5:20)
    at Object.<anonymous> (/app/index.js:4:24) {
  code: 'ERR_REQUIRE_ESM'
}
```

One common example of using require instead of import is when using typescript with es6 as target.